### PR TITLE
Add favorite Pokémon filter

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -289,7 +289,22 @@
             box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.4);
             outline: none;
         }
-        
+
+        .favorite-btn {
+            position: absolute;
+            bottom: 0.75rem;
+            left: 0.75rem;
+            background: none;
+            border: none;
+            font-size: 1.5em;
+            color: rgba(255,255,255,0.7);
+            cursor: pointer;
+            z-index: 15;
+            transition: transform 0.2s ease, color 0.2s ease;
+        }
+        .favorite-btn:hover { transform: scale(1.2); }
+        .favorite-btn.active { color: var(--electric-yellow); text-shadow: 0 0 0.25rem rgba(255,215,0,0.8); }
+
         .loading-spinner { display:inline-block;width:1rem;height:1rem;border:.125rem solid rgba(255,255,255,.3);border-radius:50%;border-top:.125rem solid #fff;animation:spin 1s linear infinite;margin-left:.5rem}
         .legendary-pokemon { box-shadow:0 0 1.25rem rgba(255,215,0,.5);animation:glowPulse 2s infinite}
         .legendary-pokemon::before { content:"⭐";position:absolute;top:.625rem;left:.625rem;font-size:1.5em;color:var(--electric-yellow);text-shadow:0 0 .3125rem rgba(255,215,0,.8);z-index:10}
@@ -485,6 +500,7 @@
                         <button class="filter-option" data-filter="all">📋 Todos los Pokémon</button>
                         <button class="filter-option" data-filter="captured">✅ Capturados</button>
                         <button class="filter-option" data-filter="missing">❌ Por capturar</button>
+                        <button class="filter-option" data-filter="favorite">🌟 Favoritos</button>
                         <button class="filter-option" data-filter="legendary">⭐ Legendarios</button>
                         <button class="filter-option" data-filter="mythical">💫 Singulares</button>
                         <button class="filter-option" data-filter="fire">🔥 Tipo Fuego</button>
@@ -615,6 +631,7 @@
             const REGIONAL_DEX_IDS = { espada_galar:27, hisui: 30, purpura:31 };
 
             let capturedPokemon = new Set();
+            let favoritePokemon = new Set();
             let currentPokedexFullData = [];
             let currentPokedexView = 'national';
             let activeFilters = new Set(['all']);
@@ -682,8 +699,10 @@
                 
                 const typeBadgesHTML=pokemon.types.map((typeEs,i)=>`<span class="type-badge type-${(pokemon.originalTypes[i]||'unknown').toLowerCase()}">${typeEs}</span>`).join('');
                 
+                const favActive = favoritePokemon.has(pokemon.nationalDexId) ? ' active' : '';
                 card.innerHTML=`
                     <button class="card-info-btn" aria-label="Ver detalles de ${pokemon.name}">❓</button>
+                    <button class="favorite-btn${favActive}" aria-label="Marcar como favorito">⭐</button>
                     <div class="pokemon-card-image-container"><img src="${pokemon.sprite||'https://via.placeholder.com/140?text=?'}" alt="${pokemon.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/140?text=?';this.onerror=null;"></div>
                     <div class="pokemon-card-info"><h3>${pokemon.name}</h3><p class="pokedex-number">${displayPokedexNumber}</p><div class="pokemon-types">${typeBadgesHTML}</div></div>
                 `;
@@ -691,15 +710,23 @@
                 const infoBtn = card.querySelector('.card-info-btn');
                 if (infoBtn) {
                     infoBtn.addEventListener('click', (event) => {
-                        event.stopPropagation(); 
+                        event.stopPropagation();
                         showPokemonModal(pokemon);
                     });
                 }
 
+                const favBtn = card.querySelector('.favorite-btn');
+                if (favBtn) {
+                    favBtn.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        toggleFavorite(pokemon, card, favBtn);
+                    });
+                }
+
                 card.addEventListener('click', (event) => {
-                    if (event.target.closest('.card-info-btn')) return; 
+                    if (event.target.closest('.card-info-btn') || event.target.closest('.favorite-btn')) return;
                     if (pokemonModalOverlay.classList.contains('visible')) return;
-                    toggleCapture(pokemon, card); 
+                    toggleCapture(pokemon, card);
                 });
                 return card;
             }
@@ -880,6 +907,24 @@
                 }
             }
 
+            function toggleFavorite(pokemon, cardElement, buttonElement) {
+                const nationalId = pokemon.nationalDexId;
+                const wasFavorite = favoritePokemon.has(nationalId);
+
+                if (wasFavorite) {
+                    favoritePokemon.delete(nationalId);
+                    if (buttonElement) buttonElement.classList.remove('active');
+                } else {
+                    favoritePokemon.add(nationalId);
+                    if (buttonElement) buttonElement.classList.add('active');
+                }
+                saveFavoritePokemon();
+
+                if (cardElement && activeFilters.has('favorite')) {
+                    applyFiltersAndRender();
+                }
+            }
+
             function getCurrentFilteredList() {
                 if (!currentPokedexFullData) return [];
                 let list = [...currentPokedexFullData];
@@ -899,6 +944,7 @@
                         switch (filter) {
                             case 'captured': list = list.filter(p => capturedPokemon.has(p.nationalDexId)); break;
                             case 'missing': list = list.filter(p => !capturedPokemon.has(p.nationalDexId)); break;
+                            case 'favorite': list = list.filter(p => favoritePokemon.has(p.nationalDexId)); break;
                             case 'legendary': list = list.filter(p => p.isLegendary); break;
                             case 'mythical': list = list.filter(p => p.isMythical); break;
                             default: if (allTypeKeys.includes(filter)) { 
@@ -916,6 +962,8 @@
             async function regionalDexFetcher(regionKey,signal){const regionNames={'espada_galar':'Espada (Galar)', 'hisui': 'Arceus (Hisui)', 'purpura':'Púrpura (Paldea)'};showStatusMessage(`⚡ Cargando Pokédex de ${regionNames[regionKey]}...`);const pokedexData=await fetchJson(`${API_BASE_URL}pokedex/${REGIONAL_DEX_IDS[regionKey]}/`,signal);if(!pokedexData||signal.aborted)return null;const batchSize=30;const results=[];for(let i=0;i<pokedexData.pokemon_entries.length;i+=batchSize){if(signal.aborted)return null;const batchPromises=pokedexData.pokemon_entries.slice(i,i+batchSize).map(async(entry)=>{if(signal.aborted)return null;const nationalId=parseInt(entry.pokemon_species.url.split('/')[entry.pokemon_species.url.split('/').length-2]);if(isNaN(nationalId))return null;const details=await getPokemonDetails(nationalId,signal);return details?{...details,regionalDexNumber:entry.entry_number}:null});results.push(...(await Promise.all(batchPromises)).filter(p=>p!=null));showStatusMessage(`⚡ Cargando Pokédex de ${regionNames[regionKey]}... ${Math.min(Math.round(((i+batchSize)/pokedexData.pokemon_entries.length)*100),100)}%`)}return results.sort((a,b)=>Number(a.regionalDexNumber)-Number(b.regionalDexNumber))}
             function loadCapturedPokemon(){const s=localStorage.getItem('pokemonUltimateCapturesV3');if(s)capturedPokemon=new Set(JSON.parse(s).map(Number))}
             function saveCapturedPokemon(){localStorage.setItem('pokemonUltimateCapturesV3',JSON.stringify(Array.from(capturedPokemon)))}
+            function loadFavoritePokemon(){const s=localStorage.getItem('pokemonUltimateFavoritesV1');if(s)favoritePokemon=new Set(JSON.parse(s).map(Number))}
+            function saveFavoritePokemon(){localStorage.setItem('pokemonUltimateFavoritesV1',JSON.stringify(Array.from(favoritePokemon)))}
             function updateCaptureCounter(animate=false,listToCount){if(!captureCounterNavElement)return;if(!listToCount){captureCounterNavElement.textContent=`0 / 0`;return}const total=listToCount.length;const capturedCount=listToCount.filter(p=>capturedPokemon.has(p.nationalDexId)).length;captureCounterNavElement.textContent=`${capturedCount} / ${total}`;if(animate){captureCounterNavElement.style.transform='scale(1.2)';setTimeout(()=>{captureCounterNavElement.style.transform='scale(1)'},200)}}
             function setActiveButtonUI(activeBtn){allNavButtons.forEach(btn=>btn.classList.remove('active'));if(activeBtn)activeBtn.classList.add('active');if(searchInput&&activeBtn&&!activeBtn.classList.contains('filter-option') && !activeBtn.id.startsWith('btnDataMenu') )searchInput.value=''}
             function updateActiveFiltersUI() {
@@ -934,8 +982,8 @@
             }
             async function fetchPokedexData(pokedexKey,fetcherFunction,buttonElement){if(buttonElement.classList.contains('active')&&!buttonElement.id.startsWith('btnDataMenu') &&!searchInput?.value.trim()){window.scrollTo({top:0,behavior:'smooth'});if(pokedexListCache.has(pokedexKey)&&currentPokedexView===pokedexKey)return}fetchAbortController?.abort();fetchAbortController=new AbortController;const signal=fetchAbortController.signal;setActiveButtonUI(buttonElement);currentPokedexView=pokedexKey;if(pokedexListCache.has(pokedexKey)){currentPokedexFullData=pokedexListCache.get(pokedexKey);applyFiltersAndRender();hideStatusMessage();if(currentPokedexFullData.length>0&&!searchInput?.value.trim())window.scrollTo({top:0,behavior:'smooth'});return}setLoadingState(buttonElement,true);if(pokedexContainer)pokedexContainer.innerHTML='';try{const data=await fetcherFunction(signal);if(data&&!signal.aborted){currentPokedexFullData=data;pokedexListCache.set(pokedexKey,data);applyFiltersAndRender();hideStatusMessage();if(data.length>0&&!searchInput?.value.trim())window.scrollTo({top:0,behavior:'smooth'})}else if(!signal.aborted){currentPokedexFullData=[];applyFiltersAndRender();showStatusMessage('❌ No se pudieron cargar los datos. Intenta de nuevo.',true)}}catch(error){if(error.name!=='AbortError'){console.error("Error en fetchPokedexData:",error);currentPokedexFullData=[];applyFiltersAndRender();showStatusMessage('❌ Error al cargar. Verifica conexión.',true)}}finally{if(!signal.aborted)setLoadingState(buttonElement,false)}}
             function handleScrollToTopButtonVisibility(){if(scrollToTopBtn){const threshold=parseFloat(getComputedStyle(document.documentElement).fontSize)*31.25;scrollToTopBtn.classList.toggle('visible',window.scrollY>threshold)}}
-            function exportCapturedData(){const dataToExport={version:"pokedex-ultimate-captures-v1.0",captured:Array.from(capturedPokemon)};const jsonString=JSON.stringify(dataToExport,null,2);const blob=new Blob([jsonString],{type:"application/json"});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download="pokedex_captures.json";document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);showNotification("💾 Datos Exportados","Tu lista de Pokémon capturados ha sido guardada.","✅")}
-            function importCapturedData(event){const file=event.target.files[0];if(!file){showNotification("⚠️ Importación Cancelada","No se seleccionó ningún archivo.","📄",4E3);return}if(file.type!=="application/json"){showNotification("❌ Error de Archivo","Por favor, selecciona un archivo .json válido.","📄",4E3);event.target.value=null;return}const reader=new FileReader;reader.onload=e=>{try{const importedData=JSON.parse(e.target.result);if(importedData&&importedData.version&&Array.isArray(importedData.captured)){const newCapturedSet=new Set(importedData.captured.map(Number).filter(id=>!isNaN(id)));capturedPokemon=newCapturedSet;saveCapturedPokemon();applyFiltersAndRender(true);showNotification("📂 Datos Importados","Tu lista de Pokémon capturados ha sido actualizada.","✅")}else{throw new Error("El archivo JSON no tiene el formato esperado.")}}catch(error){console.error("Error al importar datos:",error);showNotification("❌ Error de Importación","El archivo no pudo ser procesado. Verifica el formato.","📄",5E3)}finally{event.target.value=null}};reader.onerror=()=>{showNotification("❌ Error de Lectura","No se pudo leer el archivo seleccionado.","📄",5E3);event.target.value=null};reader.readAsText(file)}
+            function exportCapturedData(){const dataToExport={version:"pokedex-ultimate-captures-v1.1",captured:Array.from(capturedPokemon),favorites:Array.from(favoritePokemon)};const jsonString=JSON.stringify(dataToExport,null,2);const blob=new Blob([jsonString],{type:"application/json"});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download="pokedex_captures.json";document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);showNotification("💾 Datos Exportados","Tus datos han sido guardados.","✅")}
+            function importCapturedData(event){const file=event.target.files[0];if(!file){showNotification("⚠️ Importación Cancelada","No se seleccionó ningún archivo.","📄",4E3);return}if(file.type!=="application/json"){showNotification("❌ Error de Archivo","Por favor, selecciona un archivo .json válido.","📄",4E3);event.target.value=null;return}const reader=new FileReader;reader.onload=e=>{try{const importedData=JSON.parse(e.target.result);if(importedData&&importedData.version&&Array.isArray(importedData.captured)){const newCapturedSet=new Set(importedData.captured.map(Number).filter(id=>!isNaN(id)));capturedPokemon=newCapturedSet;saveCapturedPokemon();if(Array.isArray(importedData.favorites)){favoritePokemon=new Set(importedData.favorites.map(Number).filter(id=>!isNaN(id)));saveFavoritePokemon()}applyFiltersAndRender(true);showNotification("📂 Datos Importados","Tus datos han sido actualizados.","✅")}else{throw new Error("El archivo JSON no tiene el formato esperado.")}}catch(error){console.error("Error al importar datos:",error);showNotification("❌ Error de Importación","El archivo no pudo ser procesado. Verifica el formato.","📄",5E3)}finally{event.target.value=null}};reader.onerror=()=>{showNotification("❌ Error de Lectura","No se pudo leer el archivo seleccionado.","📄",5E3);event.target.value=null};reader.readAsText(file)}
             if (btnDataMenu && dataDropdownContent && dataMenuContainer) {
                 btnDataMenu.addEventListener('click', (event) => {
                     event.stopPropagation(); 
@@ -1020,6 +1068,7 @@
             window.addEventListener('scroll',handleScrollToTopButtonVisibility);
             adjustMainPadding();window.addEventListener('resize',adjustMainPadding);
             loadCapturedPokemon();
+            loadFavoritePokemon();
             updateActiveFiltersUI(); 
             if(btnHome)fetchPokedexData('national',nationalDexFetcher,btnHome);else applyFiltersAndRender();
             console.log('🎮 Pokédex Ultimate Optimizada (v22 - Nombres de Botón y Desplegable) cargada! 🎮');


### PR DESCRIPTION
## Summary
- add star favorite button for each Pokémon card
- store favorite Pokémon in localStorage
- support exporting/importing favorites
- add favorite filter option

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684042caa254832a9c1ea958a74f7ce8