### PR TITLE
Fix sword icon span

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -459,7 +459,7 @@
                 <span class="loading-spinner" style="display: none;"></span>
             </button>
             <button id="btnEspadaGalar" class="nav-button">
-                <span class="icon"⚔️</span>Espada (Galar)
+                <span class="icon">⚔️</span>Espada (Galar)
                 <span class="loading-spinner" style="display: none;"></span>
             </button>
              <button id="btnHisui" class="nav-button">


### PR DESCRIPTION
## Summary
- fix HTML to properly close sword icon span so the button shows "⚔️" correctly

## Testing
- `w3m 'POKEDEX OFICIAL.html'`

------
https://chatgpt.com/codex/tasks/task_e_684042c2b0e4832a8beef9234c672c7d