### PR TITLE
Improve comparison modal and add header controls

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -69,7 +69,19 @@
         }
         .logo-pokemon { height: 3rem; filter: drop-shadow(0.1875rem 0.1875rem 0.375rem var(--shadow-strong)); transition: transform 0.3s ease; }
         .logo-pokemon:hover { transform: scale(1.1) rotate(5deg); }
-        .banner-right-placeholder { visibility: hidden; font-family: 'Press Start 2P',cursive;font-size:0.7em;padding:.5rem .75rem }
+        .banner-right-controls { display:flex; align-items:center; gap:0.5rem; }
+        .banner-right-controls select {
+            background: rgba(255,255,255,0.8);
+            color: #1F2937;
+            border: none;
+            border-radius: 0.5rem;
+            padding: 0.25rem 0.5rem;
+            font-size: 0.75em;
+            font-weight: 700;
+        }
+        .banner-right-controls button {
+            font-size: 0.75em;
+        }
 
 
         nav {
@@ -510,11 +522,14 @@
 
         .comparison-container { max-width:60rem; }
         .comparison-grid { display:flex; gap:1rem; flex-wrap:wrap; justify-content:center; }
-        .comparison-grid .comp-column { flex:1 1 20rem; background:rgba(0,0,0,0.2); padding:1rem; border-radius:0.5rem; }
+        .comparison-grid .comp-column { flex:1 1 20rem; background:rgba(0,0,0,0.2); padding:1rem; border-radius:0.5rem; position:relative; }
+        .comparison-grid .comp-column.winner { background:var(--captured-green-bg); border:0.125rem solid var(--grass-green); }
+        .comparison-grid .comp-column.loser { background:var(--missing-red-bg); border:0.125rem solid var(--missing-red-border); }
+        .winner-label { text-align:center; font-weight:800; margin-bottom:0.5rem; color:var(--grass-green-dark); }
+        .comp-column.loser .winner-label { color:var(--missing-red-border); }
         .comparison-grid .comp-column h3 { font-family:'Press Start 2P',cursive; font-size:1em; color:var(--electric-yellow); text-align:center; margin-bottom:0.5rem; text-transform:capitalize; }
         .comparison-grid .comp-column img { display:block; margin:0 auto 0.5rem auto; max-width:8rem; }
         .comparison-grid .comp-column ul { list-style:none; padding-left:0; font-size:0.9em; }
-        .comparison-winner { text-align:center; margin-top:1rem; font-weight:800; color:var(--electric-yellow); font-size:1.1em; }
     </style>
 </head>
 <body>
@@ -524,7 +539,16 @@
             <div class="banner-center-content">
                 <img src="https://logodownload.org/wp-content/uploads/2017/08/pokemon-logo.png" alt="Pokemon Logo" class="logo-pokemon">
             </div>
-            <div class="banner-right-placeholder">Hecho por S1C4R1O</div> 
+            <div class="banner-right-controls">
+                <button id="btnSave" class="nav-button">💾 Guardar</button>
+                <select id="languageSelector">
+                    <option value="es">Español</option>
+                    <option value="en">English</option>
+                    <option value="ja">日本語</option>
+                    <option value="fr">Français</option>
+                    <option value="de">Deutsch</option>
+                </select>
+            </div>
         </div>
         <nav>
             <button id="btnHome" class="nav-button active">
@@ -757,10 +781,12 @@
             const btnAlola = document.getElementById("btnAlola");
             const filterOptions = document.querySelectorAll('.filter-option');
             
-            const dataMenuContainer = document.getElementById('dataMenuContainer'); 
-            const btnDataMenu = document.getElementById('btnDataMenu'); 
-            const dataDropdownContent = document.getElementById('dataDropdownContent'); 
+            const dataMenuContainer = document.getElementById('dataMenuContainer');
+            const btnDataMenu = document.getElementById('btnDataMenu');
+            const dataDropdownContent = document.getElementById('dataDropdownContent');
             const btnExportData = document.getElementById('btnExportData');
+            const btnSave = document.getElementById('btnSave');
+            const languageSelector = document.getElementById('languageSelector');
             const btnImportDataTrigger = document.getElementById('btnImportDataTrigger');
             const fileImporter = document.getElementById('fileImporter');
             
@@ -1016,9 +1042,14 @@
                 };
                 const score1 = totalStats(p1) * dmgMultiplier(p1,p2);
                 const score2 = totalStats(p2) * dmgMultiplier(p2,p1);
-                const winner = score1===score2? 'Empate' : (score1>score2? p1.name : p2.name);
+                const winner = score1===score2? 'draw' : (score1>score2? 'p1' : 'p2');
+                const col1Class = winner==='p1' ? 'winner' : (winner==='p2' ? 'loser' : '');
+                const col2Class = winner==='p2' ? 'winner' : (winner==='p1' ? 'loser' : '');
+                const label1 = winner==='p1' ? 'Vencedor' : (winner==='p2' ? 'Perdedor' : 'Empate');
+                const label2 = winner==='p2' ? 'Vencedor' : (winner==='p1' ? 'Perdedor' : 'Empate');
                 return `
-                    <div class="comp-column">
+                    <div class="comp-column ${col1Class}">
+                        <div class="winner-label">${label1}</div>
                         <h3>${p1.name}</h3>
                         <img src="${p1.sprite}" alt="${p1.name}">
                         <div>${buildTypes(p1)}</div>
@@ -1027,7 +1058,8 @@
                         <h4>Estadísticas</h4>
                         ${buildStats(p1)}
                     </div>
-                    <div class="comp-column">
+                    <div class="comp-column ${col2Class}">
+                        <div class="winner-label">${label2}</div>
                         <h3>${p2.name}</h3>
                         <img src="${p2.sprite}" alt="${p2.name}">
                         <div>${buildTypes(p2)}</div>
@@ -1035,8 +1067,7 @@
                         <ul>${buildAbilities(p2)}</ul>
                         <h4>Estadísticas</h4>
                         ${buildStats(p2)}
-                    </div>
-                    <div class="comparison-winner">Ganador: ${winner}</div>`;
+                    </div>`;
             }
 
             function showComparison() {
@@ -1046,16 +1077,18 @@
                 document.body.classList.add('modal-open');
             }
 
-            function hideComparison() {
+            function hideComparison(clearPins = false) {
                 comparisonOverlay.classList.remove('visible');
                 document.body.classList.remove('modal-open');
+                if (clearPins) {
+                    pinnedPokemon1 = null;
+                    pinnedPokemon2 = null;
+                    comparisonContent.innerHTML = '';
+                }
             }
 
             function clearComparison() {
-                pinnedPokemon1 = null;
-                pinnedPokemon2 = null;
-                comparisonContent.innerHTML = '';
-                hideComparison();
+                hideComparison(true);
             }
 
             function pinPokemon(pokemon) {
@@ -1095,8 +1128,8 @@
             });
 
 
-            if (comparisonCloseBtn) comparisonCloseBtn.addEventListener('click', hideComparison);
-            if (comparisonOverlay) comparisonOverlay.addEventListener('click', e => { if (e.target === comparisonOverlay) hideComparison(); });
+            if (comparisonCloseBtn) comparisonCloseBtn.addEventListener('click', () => hideComparison(true));
+            if (comparisonOverlay) comparisonOverlay.addEventListener('click', e => { if (e.target === comparisonOverlay) hideComparison(true); });
             if (comparisonClearBtn) comparisonClearBtn.addEventListener('click', clearComparison);
 
             modalCloseBtn.addEventListener('click', hidePokemonModal);
@@ -1311,6 +1344,11 @@
             if(btnPurpura)btnPurpura.addEventListener('click',()=>fetchPokedexData('purpura',()=>regionalDexFetcher('purpura',fetchAbortController.signal),btnPurpura));
             if(scrollToTopBtn)scrollToTopBtn.addEventListener('click',()=>window.scrollTo({top:0,behavior:'smooth'}));
             if(btnExportData)btnExportData.addEventListener('click',exportCapturedData);
+            if(btnSave)btnSave.addEventListener('click',exportCapturedData);
+            if(languageSelector)languageSelector.addEventListener('change',()=>{
+                const text = languageSelector.options[languageSelector.selectedIndex].text;
+                showNotification('Idioma', text, '🌐');
+            });
             if(btnKanto)btnKanto.addEventListener("click",()=>fetchPokedexData("kanto",()=>regionalDexFetcher("kanto",fetchAbortController.signal),btnKanto));
             if(btnJohto)btnJohto.addEventListener("click",()=>fetchPokedexData("johto",()=>regionalDexFetcher("johto",fetchAbortController.signal),btnJohto));
             if(btnHoenn)btnHoenn.addEventListener("click",()=>fetchPokedexData("hoenn",()=>regionalDexFetcher("hoenn",fetchAbortController.signal),btnHoenn));


### PR DESCRIPTION
## Summary
- add language selector and save button in the header
- style comparison modal to highlight winner/loser
- fix comparison modal close behavior so new comparisons can be made

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840689b45d0832ab28fcc3988db021b