### PR TITLE
Remove unused controls and clean comparison modal

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -69,20 +69,6 @@
         }
         .logo-pokemon { height: 3rem; filter: drop-shadow(0.1875rem 0.1875rem 0.375rem var(--shadow-strong)); transition: transform 0.3s ease; }
         .logo-pokemon:hover { transform: scale(1.1) rotate(5deg); }
-        .banner-right-controls { display:flex; align-items:center; gap:0.5rem; }
-        .banner-right-controls select {
-            background: rgba(255,255,255,0.8);
-            color: #1F2937;
-            border: none;
-            border-radius: 0.5rem;
-            padding: 0.25rem 0.5rem;
-            font-size: 0.75em;
-            font-weight: 700;
-        }
-        .banner-right-controls button {
-            font-size: 0.75em;
-        }
-
 
         nav {
             display: flex; justify-content: center; background: rgba(0,0,0,0.2); flex-wrap: wrap;
@@ -539,16 +525,7 @@
             <div class="banner-center-content">
                 <img src="https://logodownload.org/wp-content/uploads/2017/08/pokemon-logo.png" alt="Pokemon Logo" class="logo-pokemon">
             </div>
-            <div class="banner-right-controls">
-                <button id="btnSave" class="nav-button">💾 Guardar</button>
-                <select id="languageSelector">
-                    <option value="es">Español</option>
-                    <option value="en">English</option>
-                    <option value="ja">日本語</option>
-                    <option value="fr">Français</option>
-                    <option value="de">Deutsch</option>
-                </select>
-            </div>
+            <!-- Controles eliminados -->
         </div>
         <nav>
             <button id="btnHome" class="nav-button active">
@@ -717,10 +694,9 @@
         <div class="modal-container comparison-container">
             <div class="modal-header">
                 <h2>Comparativa</h2>
-                <button class="modal-close-btn" id="comparisonCloseBtn">&times;</button>
+                <button class="modal-close-btn" id="comparisonCloseBtn" onclick="hideComparison(true)">&times;</button>
             </div>
             <div id="comparisonContent" class="comparison-grid"></div>
-            <button id="comparisonClearBtn" class="nav-button" style="margin-top:1rem;width:100%;">Limpiar Comparación</button>
         </div>
     </div>
 
@@ -765,7 +741,6 @@
             const comparisonOverlay = document.getElementById('comparisonOverlay');
             const comparisonContent = document.getElementById('comparisonContent');
             const comparisonCloseBtn = document.getElementById('comparisonCloseBtn');
-            const comparisonClearBtn = document.getElementById('comparisonClearBtn');
 
             const btnHome = document.getElementById('btnHome');
             const btnEspadaGalar = document.getElementById('btnEspadaGalar');
@@ -785,8 +760,7 @@
             const btnDataMenu = document.getElementById('btnDataMenu');
             const dataDropdownContent = document.getElementById('dataDropdownContent');
             const btnExportData = document.getElementById('btnExportData');
-            const btnSave = document.getElementById('btnSave');
-            const languageSelector = document.getElementById('languageSelector');
+            // Botón Guardar y selector de idioma eliminados
             const btnImportDataTrigger = document.getElementById('btnImportDataTrigger');
             const fileImporter = document.getElementById('fileImporter');
             
@@ -1087,10 +1061,6 @@
                 }
             }
 
-            function clearComparison() {
-                hideComparison(true);
-            }
-
             function pinPokemon(pokemon) {
                 if (!pinnedPokemon1) {
                     pinnedPokemon1 = pokemon;
@@ -1130,7 +1100,6 @@
 
             if (comparisonCloseBtn) comparisonCloseBtn.addEventListener('click', () => hideComparison(true));
             if (comparisonOverlay) comparisonOverlay.addEventListener('click', e => { if (e.target === comparisonOverlay) hideComparison(true); });
-            if (comparisonClearBtn) comparisonClearBtn.addEventListener('click', clearComparison);
 
             modalCloseBtn.addEventListener('click', hidePokemonModal);
             pokemonModalOverlay.addEventListener('click', (event) => {
@@ -1344,11 +1313,6 @@
             if(btnPurpura)btnPurpura.addEventListener('click',()=>fetchPokedexData('purpura',()=>regionalDexFetcher('purpura',fetchAbortController.signal),btnPurpura));
             if(scrollToTopBtn)scrollToTopBtn.addEventListener('click',()=>window.scrollTo({top:0,behavior:'smooth'}));
             if(btnExportData)btnExportData.addEventListener('click',exportCapturedData);
-            if(btnSave)btnSave.addEventListener('click',exportCapturedData);
-            if(languageSelector)languageSelector.addEventListener('change',()=>{
-                const text = languageSelector.options[languageSelector.selectedIndex].text;
-                showNotification('Idioma', text, '🌐');
-            });
             if(btnKanto)btnKanto.addEventListener("click",()=>fetchPokedexData("kanto",()=>regionalDexFetcher("kanto",fetchAbortController.signal),btnKanto));
             if(btnJohto)btnJohto.addEventListener("click",()=>fetchPokedexData("johto",()=>regionalDexFetcher("johto",fetchAbortController.signal),btnJohto));
             if(btnHoenn)btnHoenn.addEventListener("click",()=>fetchPokedexData("hoenn",()=>regionalDexFetcher("hoenn",fetchAbortController.signal),btnHoenn));


### PR DESCRIPTION
## Summary
- strip save/language controls from the header
- drop comparison clear button and update close button
- inline close handler so X works reliably

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684081e362c0832a945434959d7ae3f7