### PR TITLE
Fix data dropdown and comparison close button

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -177,6 +177,9 @@
             display: flex;
             margin: 0 0.375rem;
         }
+        .data-dropdown-container #btnDataMenu {
+            margin: 0;
+        }
         .controls-container .filter-dropdown-container .filter-dropdown-btn {
             margin: 0; 
         }
@@ -197,6 +200,7 @@
             animation: fadeInSimple 0.15s ease-out;
             max-height: 60vh;
             overflow-y: auto;
+            overflow-x: hidden;
         }
         .filter-dropdown-container:hover .filter-dropdown-content,
         .data-dropdown-container:hover .data-dropdown-content { 
@@ -216,8 +220,8 @@
         .data-dropdown-item:not(.active):hover {
             background: linear-gradient(135deg, rgba(var(--electric-yellow-rgb),0.25) 0%, rgba(var(--electric-yellow-rgb),0.15) 100%);
             color: var(--electric-yellow);
-            transform: scale(1.02) translateX(0.125rem); 
-            border-radius: 0.375rem; 
+            transform: scale(1.02);
+            border-radius: 0.375rem;
         }
         .filter-option .icon,
         .data-dropdown-item .icon {
@@ -481,7 +485,7 @@
             .controls-container{flex-direction:column;gap:.5rem;margin:.5rem auto;width:90%}
             .nav-button-wrapper{width:100%;justify-content:center;margin-left:0;margin-right:0}
             #searchInput{width:100%;text-align:center}
-            .filter-dropdown-container .filter-dropdown-btn, .data-dropdown-container #btnDataMenu {width:100%;justify-content:center;margin-left:0;margin-right:0}
+            .filter-dropdown-container .filter-dropdown-btn, .data-dropdown-container #btnDataMenu {width:100%;justify-content:center;margin:0}
             .filter-dropdown-container .filter-dropdown-content, .data-dropdown-container .data-dropdown-content {min-width:unset;width:100%;left:0;transform:none;}
             .pokedex-grid{grid-template-columns:repeat(auto-fill,minmax(12.5rem,1fr));gap:1rem}
             .pokemon-card{width:12.5rem;height:17.5rem}
@@ -521,6 +525,7 @@
         #comparisonCloseBtn {
             position:absolute;
             right:0;
+            top:0;
         }
         .comparison-grid { display:flex; gap:1rem; flex-wrap:wrap; justify-content:center; }
         .comparison-grid .comp-column {
@@ -718,7 +723,7 @@
         <div class="modal-container comparison-container">
             <div class="modal-header">
                 <h2>Comparativa</h2>
-                <button class="modal-close-btn" id="comparisonCloseBtn" onclick="hideComparison(true)">&times;</button>
+                <button id="comparisonCloseBtn" class="modal-close-btn" type="button">&times;</button>
             </div>
             <div id="comparisonContent" class="comparison-grid"></div>
         </div>


### PR DESCRIPTION
## Summary
- align Data menu dropdown to the button and prevent horizontal scroll
- avoid horizontal scrolling when hovering dropdown items
- remove inline handler from comparison window and add proper close button styles

## Testing
- `tidy -errors -quiet "POKEDEX OFICIAL.html"`

------
https://chatgpt.com/codex/tasks/task_e_68408b75fe4c832aa389da3bab167547