### PR TITLE
Add center icons for legendary and mythical Pokémon

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -360,9 +360,9 @@
         
         .loading-spinner { display:inline-block;width:1rem;height:1rem;border:.125rem solid rgba(255,255,255,.3);border-radius:50%;border-top:.125rem solid #fff;animation:spin 1s linear infinite;margin-left:.5rem}
         .legendary-pokemon { box-shadow:0 0 1.25rem rgba(255,215,0,.5);animation:glowPulse 2s infinite}
-        .legendary-pokemon::before { content:"⭐";position:absolute;top:.625rem;left:.625rem;font-size:1.5em;color:var(--electric-yellow);text-shadow:0 0 .3125rem rgba(255,215,0,.8);z-index:10}
+        .legendary-pokemon::before { content:"⭐";position:absolute;top:.5rem;left:50%;transform:translateX(-50%);font-size:1.5em;color:var(--electric-yellow);text-shadow:0 0 .3125rem rgba(255,215,0,.8);z-index:10}
         .mythical-pokemon { box-shadow:0 0 1.25rem rgba(236,72,153,.5)}
-        .mythical-pokemon::before { content:"✨";position:absolute;top:.625rem;left:.625rem;font-size:1.5em;color:var(--psychic-pink);text-shadow:0 0 .3125rem rgba(236,72,153,.8);z-index:10}
+        .mythical-pokemon::before { content:"💫";position:absolute;top:.5rem;left:50%;transform:translateX(-50%);font-size:1.5em;color:var(--psychic-pink);text-shadow:0 0 .3125rem rgba(236,72,153,.8);z-index:10}
         #scrollToTop { position:fixed;bottom:1.25rem;right:1.25rem;width:3.125rem;height:3.125rem;background:var(--primary-red);color:#fff;border:none;border-radius:50%;cursor:pointer;display:flex;justify-content:center;align-items:center;font-size:1.5rem;box-shadow:0 .25rem .625rem rgba(0,0,0,.3);z-index:999;opacity:0;transform:translateY(1.25rem);transition:all .3s ease}
         #scrollToTop.visible { opacity:1;transform:translateY(0)}
         #scrollToTop:hover { background:var(--primary-blue);transform:translateY(-.3125rem)}


### PR DESCRIPTION
## Summary
- position special rarity icons at the top center of Pokémon cards
- use the same symbols as the filters for legendary (⭐) and singular (💫) Pokémon

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684bc98f9f24832a9ff51d36869f9df3