### PR TITLE
Fix capture order filter

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -1243,7 +1243,7 @@
                             case 'speed100': list = list.filter(p => (p.stats.speed||0) >= 100); break;
                             case 'captureorder':
                                 list = list.filter(p => capturedPokemon.has(p.nationalDexId));
-                                list.sort((a,b)=>captureOrder.indexOf(a.nationalDexId)-captureOrder.indexOf(b.nationalDexId));
+                                list.sort((a,b)=>captureOrder.indexOf(b.nationalDexId)-captureOrder.indexOf(a.nationalDexId));
                                 break;
                             default: if (allTypeKeys.includes(filter)) {
                                 list = list.filter(p => p.originalTypes.includes(filter));


### PR DESCRIPTION
## Summary
- show most recently captured Pokémon first when using the capture order filter

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c25cee784832ab5fc224d1c3659bb