### PR TITLE
Add zoom slider and remove card animations

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -134,29 +134,41 @@
             height: calc(var(--nav-button-height) - 0.25rem); 
             line-height: calc(var(--nav-button-height) - 0.5rem);
         }
-        .nav-button-wrapper.search-wrapper { 
-            padding: 0 0.375rem 0 0.75rem; 
-            background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%); 
+        .nav-button-wrapper.search-wrapper {
+            padding: 0 0.375rem 0 0.75rem;
+            background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%);
             border-color: #ced4da;
             box-shadow: inset 0 1px 3px rgba(0,0,0,0.05);
         }
+        .nav-button-wrapper.slider-wrapper {
+            padding: 0 0.75rem;
+            background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%);
+            border-color: #ced4da;
+            box-shadow: inset 0 1px 3px rgba(0,0,0,0.05);
+            display:flex;
+            align-items:center;
+            gap:0.5rem;
+        }
         .nav-button-wrapper.search-wrapper:hover {
             border-color: #adb5bd;
-            transform: none; 
+            transform: none;
             box-shadow: inset 0 1px 3px rgba(0,0,0,0.07);
         }
         #searchInput {
-            padding: 0.375rem 0.25rem; 
-            border: none; 
-            width: 8rem; 
-            font-size: 0.9em; 
+            padding: 0.375rem 0.25rem;
+            border: none;
+            width: 8rem;
+            font-size: 0.9em;
             font-weight: 600;
-            background: transparent; 
-            color: #374151; 
+            background: transparent;
+            color: #374151;
             outline: none;
             height: 100%;
         }
-        .nav-button-wrapper.search-wrapper .icon { 
+        #sizeSlider {
+            width: 8rem;
+        }
+        .nav-button-wrapper.search-wrapper .icon {
             color: #4B5563; font-size: 1em; margin-right: 0.375rem;
         }
         #capture-counter-nav.nav-button-wrapper { 
@@ -253,12 +265,11 @@
               right:.75rem;
               font-size:1.8em;color:var(--grass-green);font-weight:900;
               text-shadow:.0625rem .0625rem .125rem var(--shadow-dark);
-              animation:bounce 1s ease;
               z-index: 5;
           }
           .pokemon-card.favorite { border-color: var(--electric-yellow); box-shadow:0 0 1rem rgba(255,215,0,.5); }
           .pokemon-card-image-container { flex:1 1 65%;display:flex;align-items:center;justify-content:center;padding:1.5rem;border-bottom:.125rem solid #f1f5f9;overflow:hidden;position:relative;background:radial-gradient(circle at center,rgba(255,255,255,.1) 0%,transparent 70%)}
-        .pokemon-card img { max-width:8.75rem;max-height:8.75rem;width:auto;height:auto;object-fit:contain;border-radius:.75rem;transition:transform .3s ease;filter:drop-shadow(.125rem .125rem .25rem var(--shadow-dark));animation:float 3s ease-in-out infinite}
+        .pokemon-card img { max-width:8.75rem;max-height:8.75rem;width:auto;height:auto;object-fit:contain;border-radius:.75rem;transition:transform .3s ease;filter:drop-shadow(.125rem .125rem .25rem var(--shadow-dark));}
         .pokemon-card:hover img { transform:scale(1.1) rotate(5deg)}
         .pokemon-card-info { flex:1 1 35%;padding:1rem;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:.5rem}
         .pokemon-card h3 { margin:0;font-size:1.2em;font-weight:800;text-transform:capitalize;line-height:1.3;color:#1f2937;text-shadow:.0625rem .0625rem .125rem rgba(255,255,255,.8)}
@@ -487,6 +498,7 @@
             .controls-container{flex-direction:column;gap:.5rem;margin:.5rem auto;width:90%}
             .nav-button-wrapper{width:100%;justify-content:center;margin-left:0;margin-right:0}
             #searchInput{width:100%;text-align:center}
+            #sizeSlider{width:100%}
             .filter-dropdown-container .filter-dropdown-btn, .data-dropdown-container #btnDataMenu {width:100%;justify-content:center;margin:0}
             .filter-dropdown-container .filter-dropdown-content, .data-dropdown-container .data-dropdown-content {min-width:unset;width:100%;left:0;transform:none;}
             .pokedex-grid{grid-template-columns:repeat(auto-fill,minmax(12.5rem,1fr));gap:1rem}
@@ -556,7 +568,10 @@
             <div class="banner-center-content">
                 <img src="https://logodownload.org/wp-content/uploads/2017/08/pokemon-logo.png" alt="Pokemon Logo" class="logo-pokemon">
             </div>
-            <!-- Controles eliminados -->
+            <div class="nav-button-wrapper slider-wrapper">
+                <span class="icon">📐</span>
+                <input type="range" id="sizeSlider" min="80" max="200" value="150" step="10">
+            </div>
         </div>
         <nav>
             <button id="btnHome" class="nav-button active">
@@ -752,6 +767,7 @@
             const pokedexContainer = document.getElementById('pokedex-container');
             const statusMessage = document.getElementById('status-message');
             const searchInput = document.getElementById('searchInput');
+            const sizeSlider = document.getElementById('sizeSlider');
             const captureCounterNavElement = document.getElementById('capture-counter-nav');
             
             const scrollToTopBtn = document.getElementById('scrollToTop');
@@ -1459,6 +1475,12 @@
             if(btnAlola)btnAlola.addEventListener("click",()=>fetchPokedexData("alola",()=>regionalDexFetcher("alola",fetchAbortController.signal),btnAlola));
             if(btnImportDataTrigger)btnImportDataTrigger.addEventListener('click',()=>fileImporter.click());
             if(fileImporter)fileImporter.addEventListener('change',importCapturedData);
+            if(sizeSlider){
+                sizeSlider.addEventListener('input',()=>{
+                    document.documentElement.style.fontSize=sizeSlider.value+'%';
+                    adjustMainPadding();
+                });
+            }
             window.addEventListener('scroll',handleScrollToTopButtonVisibility);
             adjustMainPadding();window.addEventListener('resize',adjustMainPadding);
             loadCapturedPokemon();


### PR DESCRIPTION
## Summary
- stop bouncing and floating effects on Pokémon cards
- add a range slider to the banner to zoom the page
- scale layout through a font-size change when using the slider

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d3c3ecec8832a9552322c8034546f