### PR TITLE
Add zoom slider and remove card animations

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -69,6 +69,7 @@
         }
         .logo-pokemon { height: 3rem; filter: drop-shadow(0.1875rem 0.1875rem 0.375rem var(--shadow-strong)); transition: transform 0.3s ease; }
         .logo-pokemon:hover { transform: scale(1.1) rotate(5deg); }
+        .scale-slider { width: 8rem; margin-left: 1rem; }
 
         nav {
             display: flex; justify-content: center; background: rgba(0,0,0,0.2); flex-wrap: wrap;
@@ -258,7 +259,7 @@
           }
           .pokemon-card.favorite { border-color: var(--electric-yellow); box-shadow:0 0 1rem rgba(255,215,0,.5); }
           .pokemon-card-image-container { flex:1 1 65%;display:flex;align-items:center;justify-content:center;padding:1.5rem;border-bottom:.125rem solid #f1f5f9;overflow:hidden;position:relative;background:radial-gradient(circle at center,rgba(255,255,255,.1) 0%,transparent 70%)}
-        .pokemon-card img { max-width:8.75rem;max-height:8.75rem;width:auto;height:auto;object-fit:contain;border-radius:.75rem;transition:transform .3s ease;filter:drop-shadow(.125rem .125rem .25rem var(--shadow-dark));animation:float 3s ease-in-out infinite}
+        .pokemon-card img { max-width:8.75rem;max-height:8.75rem;width:auto;height:auto;object-fit:contain;border-radius:.75rem;transition:transform .3s ease;filter:drop-shadow(.125rem .125rem .25rem var(--shadow-dark));animation:none;}
         .pokemon-card:hover img { transform:scale(1.1) rotate(5deg)}
         .pokemon-card-info { flex:1 1 35%;padding:1rem;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:.5rem}
         .pokemon-card h3 { margin:0;font-size:1.2em;font-weight:800;text-transform:capitalize;line-height:1.3;color:#1f2937;text-shadow:.0625rem .0625rem .125rem rgba(255,255,255,.8)}
@@ -555,6 +556,7 @@
             <span class="user-nick">Hecho por S1C4R1O</span>
             <div class="banner-center-content">
                 <img src="https://logodownload.org/wp-content/uploads/2017/08/pokemon-logo.png" alt="Pokemon Logo" class="logo-pokemon">
+            <input id="scaleSlider" type="range" min="80" max="120" value="100" class="scale-slider" title="Zoom">
             </div>
             <!-- Controles eliminados -->
         </div>
@@ -799,6 +801,7 @@
             const API_BASE_URL = 'https://pokeapi.co/api/v2/';
             const MAX_NATIONAL_DEX_FETCH_LIMIT = 1025;
             const REGIONAL_DEX_IDS = { kanto:2, johto:7, hoenn:4, sinnoh:5, unova:8, kalos:12, alola:16, espada_galar:27, hisui:30, purpura:31 };
+            const scaleSlider = document.getElementById("scaleSlider");
 
             const regionIcons = {
                 national: '🏠',
@@ -1463,6 +1466,11 @@
             adjustMainPadding();window.addEventListener('resize',adjustMainPadding);
             loadCapturedPokemon();
             loadCaptureOrder();
+            if(scaleSlider){
+                const applyScale=()=>{const sc=parseFloat(scaleSlider.value)/100;document.body.style.transformOrigin="top left";document.body.style.transform=`scale(${sc})`;document.body.style.width=`${100/sc}%`;adjustMainPadding();};
+                scaleSlider.addEventListener("input",applyScale);
+                applyScale();
+            }
             loadFavoritePokemon();
             updateActiveFiltersUI(); 
             if(btnHome)fetchPokedexData('national',nationalDexFetcher,btnHome);else applyFiltersAndRender();


### PR DESCRIPTION
## Summary
- remove float animation from Pokémon images
- add a range slider in the banner to control page scale
- style the slider and implement JavaScript logic to resize the page

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_684d3c3ecec8832a9552322c8034546f