### PR TITLE
Add zoom slider and remove card animations

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -32,10 +32,11 @@
             --missing-red-bg: linear-gradient(135deg, #FFF1F2 0%, #FFE4E6 100%);
             --captured-green-bg: linear-gradient(135deg, #D1FAE5 0%, #A7F3D0 100%);
             --nav-button-height: 2.5rem; 
+            --page-zoom: 150%;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        html { font-size: 150%; scroll-behavior: smooth; }
+        html { font-size: var(--page-zoom); scroll-behavior: smooth; }
         body { height: 100%; font-family: 'Nunito', sans-serif; background: var(--gradient-background); color: #1F2937; overflow-x: hidden; }
         body.modal-open { overflow: hidden; }
 
@@ -70,6 +71,9 @@
         .logo-pokemon { height: 3rem; filter: drop-shadow(0.1875rem 0.1875rem 0.375rem var(--shadow-strong)); transition: transform 0.3s ease; }
         .logo-pokemon:hover { transform: scale(1.1) rotate(5deg); }
 
+        .zoom-control { display:flex;align-items:center;gap:.5rem;margin-left:1rem;}
+        .zoom-control label{font-size:.65em;color:var(--electric-yellow);font-weight:700;}
+        .zoom-control input[type=range]{width:8rem;}
         nav {
             display: flex; justify-content: center; background: rgba(0,0,0,0.2); flex-wrap: wrap;
             align-items: center; padding: 0.5rem 1rem; 
@@ -258,7 +262,7 @@
           }
           .pokemon-card.favorite { border-color: var(--electric-yellow); box-shadow:0 0 1rem rgba(255,215,0,.5); }
           .pokemon-card-image-container { flex:1 1 65%;display:flex;align-items:center;justify-content:center;padding:1.5rem;border-bottom:.125rem solid #f1f5f9;overflow:hidden;position:relative;background:radial-gradient(circle at center,rgba(255,255,255,.1) 0%,transparent 70%)}
-        .pokemon-card img { max-width:8.75rem;max-height:8.75rem;width:auto;height:auto;object-fit:contain;border-radius:.75rem;transition:transform .3s ease;filter:drop-shadow(.125rem .125rem .25rem var(--shadow-dark));animation:float 3s ease-in-out infinite}
+        .pokemon-card img { max-width:8.75rem;max-height:8.75rem;width:auto;height:auto;object-fit:contain;border-radius:.75rem;transition:transform .3s ease;filter:drop-shadow(.125rem .125rem .25rem var(--shadow-dark))}
         .pokemon-card:hover img { transform:scale(1.1) rotate(5deg)}
         .pokemon-card-info { flex:1 1 35%;padding:1rem;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:.5rem}
         .pokemon-card h3 { margin:0;font-size:1.2em;font-weight:800;text-transform:capitalize;line-height:1.3;color:#1f2937;text-shadow:.0625rem .0625rem .125rem rgba(255,255,255,.8)}
@@ -556,6 +560,10 @@
             <div class="banner-center-content">
                 <img src="https://logodownload.org/wp-content/uploads/2017/08/pokemon-logo.png" alt="Pokemon Logo" class="logo-pokemon">
             </div>
+            <div class="zoom-control">
+                <label for="zoomRange">Tamaño:</label>
+                <input type="range" id="zoomRange" min="100" max="200" value="150">
+            </div>
             <!-- Controles eliminados -->
         </div>
         <nav>
@@ -755,6 +763,7 @@
             const captureCounterNavElement = document.getElementById('capture-counter-nav');
             
             const scrollToTopBtn = document.getElementById('scrollToTop');
+            const zoomRange = document.getElementById("zoomRange");
             const notification = document.getElementById('notification');
 
             const pokemonModalOverlay = document.getElementById('pokemonModalOverlay');
@@ -1460,6 +1469,7 @@
             if(btnImportDataTrigger)btnImportDataTrigger.addEventListener('click',()=>fileImporter.click());
             if(fileImporter)fileImporter.addEventListener('change',importCapturedData);
             window.addEventListener('scroll',handleScrollToTopButtonVisibility);
+            if(zoomRange)zoomRange.addEventListener("input",()=>{document.documentElement.style.setProperty("--page-zoom",`${zoomRange.value}%`);adjustMainPadding();});
             adjustMainPadding();window.addEventListener('resize',adjustMainPadding);
             loadCapturedPokemon();
             loadCaptureOrder();


### PR DESCRIPTION
## Summary
- remove floating animation from Pokémon card images
- add a banner slider that controls overall zoom of the page

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684d3c3ecec8832a9552322c8034546f