### PR TITLE
Improve Pokémon Go section

### DIFF
--- a/POKEDEX OFICIAL.html
+++ b/POKEDEX OFICIAL.html
@@ -1,4 +1,3 @@
-html
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -420,6 +419,7 @@ html
             justify-content: center;
             gap: 2rem;
         }
+        .pokemon-go-info { max-width: 60rem; margin: 0 auto; padding: 1rem; }
 
         /* Enhanced Pokemon Cards */
         .pokemon-card {
@@ -786,6 +786,10 @@ html
                 <span class="icon">🏠</span>NACIONAL
                 <span class="loading-spinner" style="display: none;" aria-hidden="true"></span>
             </button>
+            <button id="btnPokemonGo" class="nav-button" aria-label="Guía de Pokémon Go">
+                <span class="icon">📱</span>Pokémon Go
+                <span class="loading-spinner" style="display: none;" aria-hidden="true"></span>
+            </button>
             <button id="btnKanto" class="nav-button" aria-label="Ver Pokédex de Kanto">
                 <span class="icon">🗾</span>Rojo (Kanto)
                 <span class="loading-spinner" style="display: none;" aria-hidden="true"></span>
@@ -1018,6 +1022,7 @@ html
             const allNavButtons = document.querySelectorAll('.nav-button:not(.dropdown-item):not(.data-menu-btn)');
             const btnKanto = document.getElementById("btnKanto");
             const btnJohto = document.getElementById("btnJohto");
+            const btnPokemonGo = document.getElementById("btnPokemonGo");
             const btnHoenn = document.getElementById("btnHoenn");
             const btnSinnoh = document.getElementById("btnSinnoh");
             const btnUnova = document.getElementById("btnUnova");
@@ -1908,6 +1913,81 @@ html
                 renderPokedex(filteredList);
                 updateCaptureCounter(animateCounter, filteredList); 
             }
+            async function showPokemonGoSection() {
+                setActiveButtonUI(btnPokemonGo);
+                currentPokedexView = "pokemon_go";
+                if(pokedexContainer) {
+                    pokedexContainer.classList.remove("pokedex-grid", "search-results");
+                    pokedexContainer.innerHTML = `<section class="pokemon-go-info"></section>`;
+                }
+
+                fetchAbortController?.abort();
+                fetchAbortController = new AbortController();
+                const signal = fetchAbortController.signal;
+
+                const categories = {
+                    raids: [
+                        "dratini","dragonair","dragonite",
+                        "gible","gabite","garchomp",
+                        "machop","machoke","machamp",
+                        "larvitar","pupitar","tyranitar",
+                        "beldum","metang","metagross"
+                    ],
+                    defense: [
+                        "chansey","blissey",
+                        "munchlax","snorlax",
+                        "slakoth","vigoroth","slaking",
+                        "beldum","metang","metagross",
+                        "togepi","togetic","togekiss"
+                    ],
+                    offense: [
+                        "machop","machoke","machamp",
+                        "timburr","gurdurr","conkeldurr",
+                        "riolu","lucario",
+                        "cranidos","rampardos",
+                        "drilbur","excadrill"
+                    ],
+                    rocket: [
+                        "machop","machoke","machamp",
+                        "magikarp","gyarados",
+                        "swinub","piloswine","mamoswine",
+                        "elekid","electabuzz","electivire",
+                        "rhyhorn","rhydon","rhyperior"
+                    ]
+                };
+
+                const sectionTitles = {
+                    raids: "🔥 Mejores Pokémon para Incursiones",
+                    defense: "🛡️ Mejores Defensores de Gimnasio",
+                    offense: "⚔️ Mejores Atacantes de Gimnasio",
+                    rocket: "🚀 Contra el Team GO Rocket"
+                };
+
+                const container = pokedexContainer?.querySelector('.pokemon-go-info');
+                if(!container) return;
+
+                showStatusMessage('⚡ Cargando guía de Pokémon Go...');
+
+                for(const [key, names] of Object.entries(categories)) {
+                    const section = document.createElement('div');
+                    section.className = 'modal-section';
+                    section.innerHTML = `<h4>${sectionTitles[key]}</h4>`;
+                    const grid = document.createElement('div');
+                    grid.className = 'pokedex-grid';
+                    section.appendChild(grid);
+                    container.appendChild(section);
+
+                    for(const name of names) {
+                        if(signal.aborted) return;
+                        const details = await getPokemonDetails(name, signal);
+                        if(details) grid.appendChild(createPokemonCard(details));
+                    }
+                }
+
+                hideStatusMessage();
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
+
 
             // Main Data Fetching Function
             async function fetchPokedexData(pokedexKey, fetcherFunction, buttonElement) {
@@ -1921,6 +2001,7 @@ html
                 const signal = fetchAbortController.signal;
                 
                 setActiveButtonUI(buttonElement);
+                pokedexContainer.classList.add("pokedex-grid");
                 currentPokedexView = pokedexKey;
 
                 if(pokedexListCache.has(pokedexKey)) {
@@ -2051,6 +2132,7 @@ html
             pokemonModalOverlay.addEventListener('click', (event) => { if(event.target === pokemonModalOverlay) hidePokemonModal(); });
 
             if(btnHome) btnHome.addEventListener('click', () => fetchPokedexData('national', nationalDexFetcher, btnHome));
+            if(btnPokemonGo) btnPokemonGo.addEventListener("click", showPokemonGoSection);
             if(btnEspadaGalar) btnEspadaGalar.addEventListener('click', () => fetchPokedexData('espada_galar', () => regionalDexFetcher('espada_galar', fetchAbortController.signal), btnEspadaGalar));
             if(btnHisui) btnHisui.addEventListener('click', () => fetchPokedexData('hisui', () => regionalDexFetcher('hisui', fetchAbortController.signal), btnHisui));
             if(btnPurpura) btnPurpura.addEventListener('click', () => fetchPokedexData('purpura', () => regionalDexFetcher('purpura', fetchAbortController.signal), btnPurpura));


### PR DESCRIPTION
## Summary
- remove stray 'html' line at the start of the document
- load Pokémon Go cards via the API for raids, gym defense, gym offense and Team GO Rocket
- add navigation button for Pokémon Go after "NACIONAL"

## Testing
- `tidy -q -errors 'POKEDEX OFICIAL.html'`

------
https://chatgpt.com/codex/tasks/task_e_684df6e39a00832a819ce5daceb0fc28